### PR TITLE
fix: update module to not run yargs on import

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const { run } = require('./');
+
+const argv = require('yargs').command('* <baseSpec> [specs...]', '', argv => {
+  argv
+    .positional('baseSpec', {
+      description: 'Base spec URL',
+      type: 'string',
+      require: true,
+    })
+    .positional('specs', {
+      description: 'List of spec URLs to merge',
+      type: 'string',
+    })
+    .option('output', {
+      alias: 'o',
+      type: 'string',
+      description: 'Output filename, by default stdout will be used',
+    });
+}).argv;
+
+if (require.main === module) {
+  run(argv);
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "yargs": "^12.0.2"
   },
   "bin": {
-    "swagger-combine": "index.js"
+    "swagger-combine": "main.js"
   },
   "engines": {
     "node": ">=7.10.1"


### PR DESCRIPTION
This module currently runs yargs when `require`d, which makes it unusable in js directly. This moves the yargs statement to a separate `main.js` file to be run as a CLI.